### PR TITLE
Add Github CI for Gradle Plugin

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,8 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        java-version: [ 8, 15, 17 ]
+        os: [ ubuntu-latest ]
       fail-fast: false
 
     steps:
@@ -33,7 +33,10 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
         run: mvn -B install
-      - name: Test with Gradle
-        run: |
-          cd ./starts-gradle-plugin
-          ./gradlew test functionalTest
+      - name: Run tests
+        working-directory: ./starts-gradle-plugin
+        run: ./gradlew test
+      - name: Run functional tests
+        if: ${{ matrix.java-version >= 15 }}
+        working-directory: ./starts-gradle-plugin
+        run: ./gradlew functionalTest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,8 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8, 15, 17 ]
-        os: [ ubuntu-latest ]
+        java-version: [ 8, 9, 10, 11, 12, 13, 14, 15 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ]
+        java-version: [ 8, 9, 10, 11, 15, 16, 17 ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
       fail-fast: false
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,11 +21,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
-          distribution:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
+      - name: Cache Maven packages
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn -B install
       - name: Test with Gradle
         run: |
           cd ./starts-gradle-plugin

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8, 9, 10, 11, 12, 13, 14, 15 ]
+        java-version: [ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
       fail-fast: false
 
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B install
+        run: mvn -B install --file pom.xml
       - name: Run tests
         working-directory: ./starts-gradle-plugin
         run: ./gradlew test

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,32 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on: push # TODO change this to be more consistent with maven workflow
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        java-version: [8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution:
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Test with Gradle
+        run: |
+          cd ./starts-gradle-plugin
+          ./gradlew test functionalTest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 # This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
 
 name: Java CI with Maven
 

--- a/starts-gradle-plugin/src/functionalTest/java/edu/illinois/starts/plugin/gradle/StartsPluginFunctionalTest.java
+++ b/starts-gradle-plugin/src/functionalTest/java/edu/illinois/starts/plugin/gradle/StartsPluginFunctionalTest.java
@@ -47,7 +47,7 @@ class StartsPluginFunctionalTest {
         writeString(getBuildFile(), """
                         plugins {
                             id 'java'
-                            id 'edu.illinois.starts' version '1.4-SNAPSHOT'
+                            id 'edu.illinois.starts'
                         }""".stripIndent());
     }
 


### PR DESCRIPTION
### Notes
- This workflow uses the [gradle-wrapper-validation action](https://github.com/marketplace/actions/gradle-wrapper-validation) and the [gradle-build-action](https://github.com/marketplace/actions/gradle-build-action), which are both authored by Gradle. Note: the gradle-wrapper-validation action was flakey in one instance (see [this workflow run](https://github.com/benjamin-shen/starts/actions/runs/3561594337/jobs/5982631472)).
- This workflow runs on push. It might be good to change this to run on push/pr to master, similarly to the Maven workflow.
- Java versions 12-14 broke because of a `maven-javadoc-plugin` related issue (see [this workflow run](https://github.com/benjamin-shen/starts/actions/runs/3561536033/jobs/5982526489)). I removed them from the CI for now.
- The functional test currently breaks on lower Java versions because of a multiline string, which is not supported until Java 15.