### PR TITLE
Remove java versions 16 and 17 from Gradle CI workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8, 9, 10, 11, 15, 16, 17 ]
+        java-version: [ 8, 9, 10, 11, 15 ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
       fail-fast: false
 


### PR DESCRIPTION
After adding back `mvn verify`, java versions 16 and 17 fail. So, I am removing them from the Gradle CI.

In the future, it may make sense to only build and verify/install `starts-core` and `starts-plugin-common`, since `starts-maven-plugin` is not a dependency for `starts-gradle-plugin`.