### PR TITLE
Maintain original excludes

### DIFF
--- a/starts-gradle-plugin/src/main/java/edu/illinois/starts/plugin/gradle/tasks/RunTask.java
+++ b/starts-gradle-plugin/src/main/java/edu/illinois/starts/plugin/gradle/tasks/RunTask.java
@@ -150,7 +150,10 @@ public class RunTask extends DiffTask implements StartsPluginRunGoal {
         TaskContainer allTasks = getProject().getTasks();
         for (Task task : allTasks) {
             if (task instanceof Test) {
-                ((Test) task).setExcludes(excludePaths);
+                Test test = ((Test) task);
+                Set<String> excludes = test.getExcludes();
+                excludes.addAll(excludePaths);
+                test.setExcludes(excludes);
             }
         }
     }


### PR DESCRIPTION
This PR fixes a bug with `dynamicallyUpdateExcludes()`, where the initial `excludes` configuration for test tasks were not being maintained. This fix has been tested with a toy project.